### PR TITLE
Increment TF version number

### DIFF
--- a/definition-files/comet/tensorflow/tensorflow-cpu.def
+++ b/definition-files/comet/tensorflow/tensorflow-cpu.def
@@ -5,7 +5,7 @@ OSVersion: xenial
 %labels
 
     APPLICATION_NAME tensorflow
-    APPLICATION_VERSION 1.11
+    APPLICATION_VERSION 1.12
     APPLICATION_URL https://www.tensorflow.org
 
     SYSTEM_NAME comet
@@ -103,7 +103,7 @@ OSVersion: xenial
     # Download TensorFlow source
     git clone https://github.com/tensorflow/tensorflow
     cd /opt/tensorflow
-    git checkout r1.11
+    git checkout r1.12
 
     # Build and install TensorFlow for python(2)
     echo '#!/usr/bin/expect -f' > install-tensorflow-python.exp
@@ -151,7 +151,7 @@ OSVersion: xenial
     bazel build --local_resources 2048,.5,1.0 -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" //tensorflow/tools/pip_package:build_pip_package
     bazel-bin/tensorflow/tools/pip_package/build_pip_package tensorflow_pkg
 
-    pip install tensorflow_pkg/tensorflow-1.11.0-cp27-cp27mu-linux_x86_64.whl
+    pip install tensorflow_pkg/tensorflow-1.12.0-cp27-cp27mu-linux_x86_64.whl
 
     # Install common python packages for data science and machine learning applications
     apt-get -y install python-scipy
@@ -242,7 +242,7 @@ OSVersion: xenial
     bazel build --local_resources 2048,.5,1.0 -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" //tensorflow/tools/pip_package:build_pip_package
     bazel-bin/tensorflow/tools/pip_package/build_pip_package tensorflow_pkg
 
-    pip3 install tensorflow_pkg/tensorflow-1.11.0-cp35-cp35m-linux_x86_64.whl
+    pip3 install tensorflow_pkg/tensorflow-1.12.0-cp35-cp35m-linux_x86_64.whl
 
     # Install common python3 packages for data science and machine learning applications
     apt-get -y install python3-scipy

--- a/definition-files/comet/tensorflow/tensorflow-gpu.def
+++ b/definition-files/comet/tensorflow/tensorflow-gpu.def
@@ -5,7 +5,7 @@ OSVersion: xenial
 %labels
 
     APPLICATION_NAME tensorflow
-    APPLICATION_VERSION 1.11
+    APPLICATION_VERSION 1.12
     APPLICATION_URL https://www.tensorflow.org
 
     SYSTEM_NAME comet
@@ -289,7 +289,7 @@ OSVersion: xenial
     # Download TensorFlow source
     git clone https://github.com/tensorflow/tensorflow
     cd /opt/tensorflow
-    git checkout r1.11
+    git checkout r1.12
 
     # Build and install TensorFlow for python(2)
     echo '#!/usr/bin/expect -f' > install-tensorflow-python.exp
@@ -366,7 +366,7 @@ OSVersion: xenial
     bazel build --local_resources 2048,.5,1.0 -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" --config=cuda //tensorflow/tools/pip_package:build_pip_package
     bazel-bin/tensorflow/tools/pip_package/build_pip_package tensorflow_pkg
 
-    pip install tensorflow_pkg/tensorflow-1.11.0-cp27-cp27mu-linux_x86_64.whl
+    pip install tensorflow_pkg/tensorflow-1.12.0-cp27-cp27mu-linux_x86_64.whl
 
     # Install common python packages for data science and machine learning applications
     apt-get -y install python-scipy
@@ -479,7 +479,7 @@ OSVersion: xenial
     bazel build --local_resources 2048,.5,1.0 -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" --config=cuda //tensorflow/tools/pip_package:build_pip_package
     bazel-bin/tensorflow/tools/pip_package/build_pip_package tensorflow_pkg
 
-    pip3 install tensorflow_pkg/tensorflow-1.11.0-cp35-cp35m-linux_x86_64.whl
+    pip3 install tensorflow_pkg/tensorflow-1.12.0-cp35-cp35m-linux_x86_64.whl
 
     # Install common python3 packages for data science and machine learning applications
     apt-get -y install python3-scipy


### PR DESCRIPTION
Is it possible to support Tensorflow 1.12? As I understand this will be the last major release of Tensorflow before version 2.0.

If this is too incremental to merit the disk space, perhaps we could have a `ubuntu-cuda.def` which has CUDA-9.0 and CuDNN 7.0 (as opposed to CUDA-9.2 and CuDNN 7.1) so that I can just `pip install tensorflow-gpu` in a virtualenv? The official wheels are built with 9/7.